### PR TITLE
Added pages and page navigation bar at the bottom of the Browse page

### DIFF
--- a/Parduotuve/Components/Pages/Browse.razor
+++ b/Parduotuve/Components/Pages/Browse.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@page "/{Page:int}"
 @using Parduotuve.Data.Repositories
 @using Parduotuve.Data.Entities
 @using Parduotuve.Services
@@ -17,8 +18,8 @@
     <input type="text" placeholder="Search by skin name" @bind="searchQuery" @oninput="SearchSkins" style="margin-left: 10px;" />
 </div>
 
-<div style="padding: 100px; text-align: center;">
-    @foreach (Skin skin in FilteredSkins)
+<div style="padding: 10px; text-align: center;">
+    @foreach (Skin skin in GetPageContents())
     {
         <div @onclick="@((e) => EntryClicked(false,skin.Id,e))" style="border: 1px solid black;padding:10px; margin:15px;text-align:center;cursor:pointer;display:inline-block;">
             <img src=@skin.SplashUrl style="margin:10px;height:360px;width:200px" />
@@ -37,15 +38,78 @@
     }
 </div>
 
+<nav>
+    <ul class="pagination justify-content-center">
+        @if (PageIndex == 0)
+        {
+            <li class="page-item disabled">
+                <a class="page-link" tabindex="-1">Previous</a>
+            </li>
+        }
+        else
+        {
+            <li class="page-item">
+                <a class="page-link" href="/@(PageIndex-1)" tabindex="-1">Previous</a>
+            </li>
+        }
+
+        @foreach (int indice in GetSurroundingPageIndices())
+        {
+            @if (indice == PageIndex)
+            {
+                <li class="page-item active"><a class="page-link" href="/@(indice)">@(indice + 1)</a></li>
+            }
+            else
+            {
+                <li class="page-item"><a class="page-link" href="/@(indice)">@(indice + 1)</a></li>
+            }
+        }
+
+        @if (PageIndex >= PageCount - 1)
+        {
+            <li class="page-item disabled">
+                <a class="page-link">Next</a>
+            </li>
+        }
+        else
+        {
+            <li class="page-item">
+                <a class="page-link" href="/@(PageIndex+1)" data-enhance-nav="false">Next</a>
+            </li>
+        }
+    </ul>
+</nav>
+
 @code {
+    [Parameter]
+    public int? Page { get; set; }
     private IEnumerable<Skin> Skins { get; set; } = new List<Skin>();
     private IEnumerable<Skin> FilteredSkins { get; set; } = new List<Skin>();
     private string selectedSortOption = "ChampionName";
     private string searchQuery = string.Empty;
+    private static int ItemsPerPage = 10;
+    private static int BarLength = 2;
+    private int PageIndex { get; set; } = 0;
+    private int PageCount { get { return FilteredSkins.Chunk(ItemsPerPage).ToArray().Length; } }
 
     protected override async Task OnInitializedAsync()
     {
         await LoadSkinsAsync();
+    }
+
+    public async override Task SetParametersAsync(ParameterView parameters)
+    {
+        await base.SetParametersAsync(parameters);
+        Page = Page ?? 0;
+        if(Page < 0)
+        {
+            Page = 0;
+        }
+        else if(Page >= PageCount)
+        {
+            Page = PageCount - 1;
+        }
+        PageIndex = (int)Page;
     }
 
     private async Task SortSkins(ChangeEventArgs e)
@@ -66,6 +130,52 @@
         searchQuery = e.Value?.ToString() ?? string.Empty;
         ApplySearchFilter();
         StateHasChanged();
+    }
+
+    private IEnumerable<Skin> GetPageContents()
+    {
+        return FilteredSkins.Chunk(ItemsPerPage).ToArray()[PageIndex];
+    }
+
+    private IEnumerable<int> GetSurroundingPageIndices()
+    {
+        int leftCursor = PageIndex;
+        int rightCursor = PageIndex;
+        List<int> indices = new List<int>();
+
+        indices.Add(PageIndex);
+
+        for(int x = 0; x < BarLength; x++)
+        {
+            if(leftCursor - 1 < 0 && rightCursor + 1 >= PageCount)
+            {
+                break;
+            }
+
+            if(leftCursor - 1 >= 0)
+            {
+                leftCursor -= 1;
+                indices.Insert(0, leftCursor);
+            }
+            else
+            {
+                rightCursor += 1;
+                indices.Add(rightCursor);
+            }
+
+            if(rightCursor + 1 < PageCount)
+            {
+                rightCursor += 1;
+                indices.Add(rightCursor);
+            }
+            else if(leftCursor -1 >= 0)
+            {
+                leftCursor -= 1;
+                indices.Insert(0, leftCursor);
+            }
+        }
+
+        return indices;
     }
 
     private void ApplySearchFilter()


### PR DESCRIPTION
The Browse page now accepts a URL parameter, which determines which page should be open. In addition, a navigation bar at the bottom of the Browse page was created, which allows the user to navigate to different pages. The element count of the navigation bar as well as the item count per page can be changed through their corresponding static variables